### PR TITLE
OPS-3191 Updated schulcloud-calendar-init role to be togglable

### DIFF
--- a/ansible/roles/schulcloud-calendar-init/tasks/main.yml
+++ b/ansible/roles/schulcloud-calendar-init/tasks/main.yml
@@ -3,9 +3,31 @@
       kubeconfig: ~/.kube/config
       namespace: "{{ NAMESPACE }}"
       template: configmap_file_init_db.yml.j2
+    when: WITH_CALENDAR_INIT
+
+  - name: Calendar db init job config map
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      state: absent
+      apiVersion: v1
+      kind: ConfigMap
+      name: calendar-db-init-file
+    when: not WITH_CALENDAR_INIT
 
   - name: Calendar db init job
     kubernetes.core.k8s:
       kubeconfig: ~/.kube/config
       namespace: "{{ NAMESPACE }}"
       template: job_init_db.yml.j2
+    when: WITH_CALENDAR_INIT
+
+  - name: Calendar db init job
+    kubernetes.core.k8s:
+      kubeconfig: ~/.kube/config
+      namespace: "{{ NAMESPACE }}"
+      state: absent
+      apiVersion: batch/v1
+      kind: Job
+      name: calendar-db-init-job
+    when: not WITH_CALENDAR_INIT


### PR DESCRIPTION
# Description
Updated the schulcloud-calendar-init role to be togglable with the WITH_CALENDAR_INIT variable

## Links to Tickets or other pull requests


## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
Needs the WITH_CALENDAR_INIT variable from https://github.com/hpi-schul-cloud/dof_app_deploy/pull/176
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
